### PR TITLE
#389 Fixed the fatal error issue by redeclaring missing static properties

### DIFF
--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -342,6 +342,20 @@ final class Plugin {
 final class Analog_Templates {
 
 	/**
+	 * Holds key for Favorite templates user meta.
+	 *
+	 * @var string
+	 */
+	public static $user_meta_prefix = 'analog_library_favorites';
+
+	/**
+	 * Holds key for Favorite blocks user meta.
+	 *
+	 * @var string
+	 */
+	public static $user_meta_block_prefix = 'analog_block_favorites';
+
+	/**
 	 * Current plugin version.
 	 *
 	 * @var string

--- a/inc/Plugin.php
+++ b/inc/Plugin.php
@@ -342,20 +342,6 @@ final class Plugin {
 final class Analog_Templates {
 
 	/**
-	 * Holds key for Favorite templates user meta.
-	 *
-	 * @var string
-	 */
-	public static $user_meta_prefix = 'analog_library_favorites';
-
-	/**
-	 * Holds key for Favorite blocks user meta.
-	 *
-	 * @var string
-	 */
-	public static $user_meta_block_prefix = 'analog_block_favorites';
-
-	/**
 	 * Current plugin version.
 	 *
 	 * @var string

--- a/inc/api/class-local.php
+++ b/inc/api/class-local.php
@@ -7,7 +7,7 @@
 
 namespace Analog\API;
 
-use Analog\Analog_Templates;
+use Analog\Plugin;
 use Analog\Base;
 use Analog\Classes\Import_Image;
 use Analog\Elementor\Kit\Manager;
@@ -178,9 +178,9 @@ class Local extends Base {
 	 * @return WP_REST_Response
 	 */
 	public function mark_as_favorite( WP_REST_Request $request ) {
-		$type = Analog_Templates::$user_meta_prefix;
+		$type = Plugin::$user_meta_prefix;
 		if ( ! empty( $request->get_param( 'type' ) ) && 'block' === $request->get_param( 'type' ) ) {
-			$type = Analog_Templates::$user_meta_block_prefix;
+			$type = Plugin::$user_meta_block_prefix;
 		}
 		$id        = $request->get_param( 'id' );
 		$favorite  = $request->get_param( 'favorite' );


### PR DESCRIPTION
Fixed the fatal error issue by redeclaring missing static properties.

Properties fetched from the following commit: https://github.com/analogwp/analogwp-templates/commit/bf53feef570bbb27052fed137b34edf96bf70134