### PR TITLE
Resolves #420 column gap for both new and old DOM structure

### DIFF
--- a/inc/elementor/class-typography.php
+++ b/inc/elementor/class-typography.php
@@ -437,7 +437,7 @@ class Typography extends Module {
 					'type'       => Controls_Manager::DIMENSIONS,
 					'size_units' => array( 'px', 'em', '%' ),
 					'selectors'  => array(
-						"{{WRAPPER}} .elementor-column-gap-{$key} > .elementor-row > .elementor-column > .elementor-element-populated"
+						"{{WRAPPER}} .elementor-column-gap-{$key} .elementor-column > .elementor-element-populated"
 						=> 'padding: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}}',
 					),
 				)


### PR DESCRIPTION
Resolves #420 
Fixed the column gap not applying for the new Elementor DOM structure with backward compatibility for older Dom structure